### PR TITLE
Bug fixes when reading VCF file

### DIFF
--- a/vireoSNP/utils/io_utils.py
+++ b/vireoSNP/utils/io_utils.py
@@ -48,7 +48,7 @@ def read_vartrix(alt_mtx, ref_mtx, cell_file, vcf_file=None):
     """
     if vcf_file is not None:
         cell_dat = load_VCF(vcf_file, load_sample=False, biallelic_only=False)
-        cell_dat['variants'] = np.array(cell_vcf['variants'])
+        cell_dat['variants'] = np.array(cell_dat['variants'])
     else:
         cell_dat = {}
     cell_dat['AD'] = mmread(alt_mtx).tocsc()

--- a/vireoSNP/utils/vireo_wrap_v02.py
+++ b/vireoSNP/utils/vireo_wrap_v02.py
@@ -1,3 +1,4 @@
+import sys
 import numpy as np
 from .vireo_base import normalize, greed_match, donor_select
 from .vireo_model_v02 import vireo_core


### PR DESCRIPTION
I encountered an issue when reading VCF file specified as part of the input list for vartrix. I noticed that this was due to an undeclared variable, likely due to the variable not being renamed during refactoring of the variable. 

I also ran code review on the vireo repository and identified a missing dependency in the vireo_wrap_v02.py.