### PR TITLE
Fixed error in output with --noDoublet & slice cells

### DIFF
--- a/vireoSNP/vireo.py
+++ b/vireoSNP/vireo.py
@@ -74,7 +74,7 @@ def main():
         action="store_true", help="If use, turn off plotting GT distance.")
     group1.add_option("--randSeed", type="int", dest="rand_seed", default=None,
         help="Seed for random initialization [default: %default]")
-    group1.add_option("--cellRange", type="int", dest="cell_range", default=None,
+    group1.add_option("--cellRange", type="str", dest="cell_range", default=None,
         help="Range of cells to process, eg. 0-10000 [default: all]")
     # group1.add_option("--nproc", "-p", type="int", dest="nproc", default=1,
     #     help="Number of subprocesses [default: %default]")

--- a/vireoSNP/vireo.py
+++ b/vireoSNP/vireo.py
@@ -128,6 +128,8 @@ def main():
     ## subset input cell data if necessary
     if options.cell_range is not None:
         cellRange = options.cell_range.split("-")
+        cellRange[0] = int(cellRange[0])
+        cellRange[1] = int(cellRange[1])
         cell_dat['AD'] = cell_dat['AD'][:,cellRange[0]:cellRange[1]]
         cell_dat['DP'] = cell_dat['DP'][:,cellRange[0]:cellRange[1]]
         cell_dat['samples'] = cell_dat['samples'][cellRange[0]:cellRange[1]]


### PR DESCRIPTION
Hi,

First of all thanks for developing Vireo (and cellsnp-lite), it's really a great tool that I use quite frequently in my work. Excellent job!

I have encountered a problem when running with the `--noDoublet` mode, and found the problem: You create a matrix of zeroes in the shape of ncells x possible donor combinations but you had ncells x all possible cell combinations in that line.
Furthermore I added an int() in that line because the division would return float values.

Additionally, I have been having some scipy matrix errors during donor deconvolution when running vireo on big datasets that are deeply covered (eg. 500,000 high quality variants x 50,000 cells). This can be avoided when running fewer cells, so for convenience I added a flag to run only a subset of the input cells:  `--cellRange`, eg. `--cellRange 0-10000` to run the first 10,000 cells in the cellSNP data.
This also helps to use less RAM!

Hope you find this useful and let me know if anything is unclear.

Best,
Christoph