### PR TITLE
Version less memory intensive and better MT handling + merge bams w/o vcf

### DIFF
--- a/simulate/README.rst
+++ b/simulate/README.rst
@@ -32,27 +32,35 @@ For details of all arguments: type ``python synth_pool.py  -h``
 
 .. code-block:: html
 
-   Usage: synth_pool.py [options]
+  Usage: synth_pool.py [options]
 
-   Options:
+  Options:
     -h, --help            show this help message and exit
     -s SAM_FILES, --samFiles=SAM_FILES
-                            Input sam files, comma separated.
+                          Input bam or sam files, comma separated.
     -b BARCODES_FILES, --barcodeFiles=BARCODES_FILES
-                            Input barcode files, comma separated.
+                          Input barcode files, comma separated.
     -r REGION_FILE, --regionFile=REGION_FILE
-                            Input SNP list.
+                          Input SNP list.
     -d DOUBLET_RATE, --doubletRate=DOUBLET_RATE
-                            Doublet rate [default: n/100000]
+                          Doublet rate [default: n/100000]
     -o OUT_DIR, --outDir=OUT_DIR
-                            Directory for output files: pooled.bam and
-                            barcodes_pool.tsv.
+                          Directory for output files: pooled.bam and
+                          barcodes_pool.tsv.
     -p NPROC, --nproc=NPROC
-                            Number of subprocesses [default: 1]
+                          Number of subprocesses. This will create
+                          <nproc>*<samFiles> subprocesses. For example with
+                          nproc=10 and 3 input bam/sam files, 30 sub jobs will
+                          be created. When running with --merge, this will send
+                          a job per file if it is >1 [default: 1]
+    -m, --merge           Merge instead of fetch [default: False]
+    --shuffle             Shuffle the positions, only works on MT [default:
+                          False]
+    --test=TEST_VAL       Set it to a value >0 to run only <test> read [default:-1]
 
     Cell barcodes sampling:
-        --nCELL=N_CELL      The number of cells in each sample [default: none]
-        --minorSAMPLE=MINOR_SAMPLE
-                            Ratio size of minor sample [default: 1.0]
-        --randomSEED=RANDOM_SEED
-                            The random seed in numpy [default: none]
+      --nCELL=N_CELL      The number of cells in each sample [default: none]
+      --minorSAMPLE=MINOR_SAMPLE
+                          Ratio size of minor sample [default: 1.0]
+      --randomSEED=RANDOM_SEED
+                          The random seed in numpy [default: none]

--- a/simulate/README.rst
+++ b/simulate/README.rst
@@ -19,6 +19,9 @@ mixture:
   same sample 3.
 * For all BAM files, only keep the reads covering the given variants by using 
   ``--regionFile`` in VCF format
+* In case you do not have a VCF file with given variants or if you need to be 
+  more inclusive in your variant choice, you can use the ``--noregionFile`` option 
+  instead of ``--regionFile`` (those two are mutually exclusive)
 * Extra cells are added to the same number of singletons to generate doublets. 
   The number of doublets are defined by the total cells and the doublet rate
   ``--doubletRate``
@@ -42,6 +45,8 @@ For details of all arguments: type ``python synth_pool.py  -h``
                           Input barcode files, comma separated.
     -r REGION_FILE, --regionFile=REGION_FILE
                           Input SNP list.
+    --noregionFile        Run the synthetic pooling without a given list of 
+                          variant, mutually exclusive with --regionFile [default: False]
     -d DOUBLET_RATE, --doubletRate=DOUBLET_RATE
                           Doublet rate [default: n/100000]
     -o OUT_DIR, --outDir=OUT_DIR
@@ -51,9 +56,8 @@ For details of all arguments: type ``python synth_pool.py  -h``
                           Number of subprocesses. This will create
                           <nproc>*<samFiles> subprocesses. For example with
                           nproc=10 and 3 input bam/sam files, 30 sub jobs will
-                          be created. When running with --merge, this will send
+                          be created. When running with --noregionFile, this will send
                           a job per file if it is >1 [default: 1]
-    -m, --merge           Merge instead of fetch [default: False]
     --shuffle             Shuffle the positions, only works on MT [default:
                           False]
     --test=TEST_VAL       Set it to a value >0 to run only <test> read [default:-1]

--- a/simulate/synth_pool.py
+++ b/simulate/synth_pool.py
@@ -97,7 +97,6 @@ def pool_barcodes(barcodes, out_dir, doublet_rate=None, sample_suffix=True,
 
 def fetch_reads(samFile_list, chroms, positions, outbam, 
                 barcodes_in, barcodes_out=None, cell_tag='CB', test_val=-1):
-    print('running fetch reads with vcf')
     """
     """
     jobname=outbam
@@ -304,6 +303,8 @@ def main():
 
 
     if not options.merge:
+        print('running fetch reads with vcf')
+
         ## VCF file
         vcf_dat = load_VCF(options.region_file, biallelic_only=False, 
                            load_sample=False)

--- a/simulate/synth_pool.py
+++ b/simulate/synth_pool.py
@@ -316,7 +316,7 @@ def main():
         if (options.nproc == 1):
             BAM_FILE = out_dir + "/pooled.bam"
             fetch_reads(samFile_list, chroms, positions, 
-                        BAM_FILE, barcodes_in, barcodes_out, test=options.test)
+                        BAM_FILE, barcodes_in, barcodes_out, test_val=options.test_val)
 
         elif (options.nproc > 1):
             result = []
@@ -341,7 +341,7 @@ def main():
                     BAM_FILE = out_dir + "/pooled_temp_File{}_Pos{}.bam".format(ii,n)
                     result.append(pool.apply_async(fetch_reads, ([samFile_list[ii]], 
                                                                  chroms[posrange[n][0]:posrange[n][1]], positions[posrange[n][0]:posrange[n][1]], BAM_FILE, [barcodes_in[ii]], 
-                                                                 [barcodes_out[ii]], "CB", test_val=options.test_val), callback=show_progress))
+                                                                 [barcodes_out[ii]], "CB", options.test_val), callback=show_progress))
 
             pool.close()
             pool.join()

--- a/simulate/synth_pool.py
+++ b/simulate/synth_pool.py
@@ -96,7 +96,7 @@ def pool_barcodes(barcodes, out_dir, doublet_rate=None, sample_suffix=True,
 
 
 def fetch_reads(samFile_list, chroms, positions, outbam, 
-                barcodes_in, barcodes_out=None, cell_tag='CB'), test=-1:
+                barcodes_in, barcodes_out=None, cell_tag='CB', test=-1):
     print('running fetch reads with vcf')
     """
     """

--- a/simulate/synth_pool.py
+++ b/simulate/synth_pool.py
@@ -1,7 +1,9 @@
 # Sythetic mixture of bam files from multiple samples
 # Author: Yuanhua Huang
 # Date: 15-06-2019
-
+import time
+start=time.time()
+import datetime
 import os
 import sys
 import pysam
@@ -12,7 +14,7 @@ import multiprocessing
 from optparse import OptionParser, OptionGroup
 from cellSNP.utils.vcf_utils import load_VCF
 from cellSNP.utils.pileup_utils import check_pysam_chrom
-
+import random
 
 def show_progress(RV=None):
     return RV
@@ -49,8 +51,7 @@ def pool_barcodes(barcodes, out_dir, doublet_rate=None, sample_suffix=True,
             barcodes_out.append([x[:-1]+str(ss+1) for x in barcodes[ss]])
     else:
         barcodes_out = barcodes.copy()
-    barcodes_flat = list(itertools.chain(*barcodes_out))
-            
+    barcodes_flat = list(itertools.chain(*barcodes_out))      
     n_cells = len(barcodes_flat)
     if doublet_rate is None:
         doublet_rate = n_cells / 100000.0
@@ -61,10 +62,8 @@ def pool_barcodes(barcodes, out_dir, doublet_rate=None, sample_suffix=True,
         n_doublets = 0
     else:
         n_doublets = round(n_cells / (1 + 1 / doublet_rate))
-        
-    print(n_cells, n_doublets)
-
     perm_idx = np.random.permutation(n_cells)
+
     for ii in range(n_doublets):
         if (barcodes_flat[perm_idx[ii]].split("-")[1] == 
             barcodes_flat[perm_idx[ii + n_doublets]].split("-")[1]):
@@ -73,7 +72,7 @@ def pool_barcodes(barcodes, out_dir, doublet_rate=None, sample_suffix=True,
             _barcode = barcodes_flat[perm_idx[ii]] + "D"
         barcodes_flat[perm_idx[ii]] = _barcode
         barcodes_flat[perm_idx[ii + n_doublets]] = _barcode
-
+        
     start_idx = 0
     for ss in range(len(barcodes_out)):
         _n_cell = len(barcodes_out[ss])
@@ -98,50 +97,107 @@ def pool_barcodes(barcodes, out_dir, doublet_rate=None, sample_suffix=True,
 
 def fetch_reads(samFile_list, chroms, positions, outbam, 
                 barcodes_in, barcodes_out=None, cell_tag='CB'):
+    print('running fetch reads with vcf')
     """
     """
+    jobname=outbam
     samFile_list = [check_pysam_chrom(x, chroms[0])[0] for x in samFile_list]
     outbam = pysam.AlignmentFile(outbam, "wb", template=samFile_list[0])
     if barcodes_out is None:
         barcodes_out = barcodes_in.copy()
     
+
+    print ('N positions     : ',len(positions))
+    print ('First positions : ',positions[0])
+    print ('Last positions  : ',positions[-1])
+ 
     for ss in range(len(samFile_list)):
+        print('file {} out of {} type {}'.format(ss+1,len(samFile_list), samFile_list[ss]))
         samFile = samFile_list[ss]
         _barcodes_in = barcodes_in[ss]
         _barcodes_out = barcodes_out[ss]
-        
         READ_CNT = 0
-        reads_all = []
-        for i in range(len(positions)):
+        reads_all = {}
+        reads_all_test =[]
+        npostot=len(positions)
+        for i in range(npostot):
+            if int(i+1) % 10000 == 0:
+                print("BAM: {} positions read: {:.2f}M   percent: {:.2f}%   reads stored: {}" .format(jobname.split('/')[-1], (i+1)/1000000, float(100*(i+1))/float(npostot), len(reads_all)))
             chrom = chroms[i]
             POS = positions[i]
-            
+            read=0
+            goodread=0
+            storeread=0
             for _read in samFile.fetch(chrom, POS-1, POS):
+                read+=1
                 if _read.has_tag(cell_tag) == False:
                     continue
                 try:
                     idx = _barcodes_in.index(_read.get_tag(cell_tag))
                     _read.set_tag(cell_tag, _barcodes_out[idx])
+                    goodread+=1
                 except ValueError:
                     continue
-                reads_all.append(_read)
                 
-                READ_CNT += 1
-                if READ_CNT % 100000 == 0:
-                    print("BAM%d: %.2fM reads." %(ss+1, READ_CNT/1000000))
-        
-        # remove redundant reads (one read may be called multiple times)
-        reads_all = set(reads_all)
-        print(len(reads_all), READ_CNT)
-        for _read in reads_all:
-            outbam.write(_read)
-            
+                readID = _read.query_name
+                if reads_all.get(readID,-1)<0:
+                    outbam.write(_read)
+                    reads_all[readID]=storeread
+                    storeread+=1
         samFile.close()
     outbam.close()
+    print('fetch reads done for file {}'.format(jobname))
+    return None
+
+
+def merge_bams(samFile_list, outbam, barcodes_in, barcodes_out=None, cell_tag='CB'):
+    """
+    """
+    print('running fetch reads without vcf')
+
+    jobname=outbam
+    samFile_list = [check_pysam_chrom(x, "1")[0] for x in samFile_list]
+    outbam = pysam.AlignmentFile(outbam, "wb", template=samFile_list[0])
+
+    if barcodes_out is None:
+        barcodes_out = barcodes_in.copy()
+    
+
+    for ss in range(len(samFile_list)):
+        print('file {} out of {} type {}'.format(ss+1,len(samFile_list), samFile_list[ss]))
+        samFile = samFile_list[ss]
+        _barcodes_in = barcodes_in[ss]
+        _barcodes_out = barcodes_out[ss]
+        READ_CNT = 0
+        reads_all = {}
+        reads_all_test =[]
+        count=0
+        storeread=0
+        for _read in samFile.fetch():
+            if int(count+1) % 100000 == 0:
+                print("BAM: {} reads read: {:.2f}M  reads stored: {}" .format(jobname.split('/')[-1], (count+1)/1000000, len(reads_all)))
+            count+=1
+            if _read.has_tag(cell_tag) == False:
+                continue
+            try:
+                idx = _barcodes_in.index(_read.get_tag(cell_tag))
+                _read.set_tag(cell_tag, _barcodes_out[idx])
+            except ValueError:
+                continue
+                
+            readID = _read.query_name
+            if reads_all.get(readID,-1)<0:
+                outbam.write(_read)
+                reads_all[readID]=storeread
+                storeread+=1
+        samFile.close()
+    outbam.close()
+    print('merge done for file {}'.format(jobname))
     return None
 
 
 def main():
+
     import warnings
     warnings.filterwarnings('error')
 
@@ -158,8 +214,13 @@ def main():
     parser.add_option("--outDir", "-o", dest="out_dir", default=None,
         help=("Directory for output files: pooled.bam and barcodes_pool.tsv."))
     parser.add_option("--nproc", "-p", type="int", dest="nproc", default=1,
-        help="Number of subprocesses [default: %default]")
+        help="Number of subprocesses. This will create <nproc>*<samFiles> subprocesses. For example with nproc=10 and 3 input bam/sam files, 30 sub jobs will be created [default: %default]")
+    parser.add_option("--merge", "-m", action="store_true", default=False,
+        help="Merge instead of fetch [default: %default]")
+    parser.add_option("--shuffle", action="store_true", default=False,
+        help="Shuffle the positions, only works on MT [default: %default]")
 
+    
     group = OptionGroup(parser, "Cell barcodes sampling")
     group.add_option("--nCELL", type="int", dest="n_cell", default=None, 
         help="The number of cells in each sample [default: %default]")
@@ -202,65 +263,146 @@ def main():
     if len(barcodes_files) != len(samFile_list):
         print("Error: barcodes files are not equal to sam files.")
         sys.exit(1)
-    
+        
+
     barcodes_in = []
     for _bar in barcodes_files:
         fid = open(_bar, 'r')
         all_lines = [x.rstrip() for x in fid.readlines()]
-        fid.close()
+        fid.close()        
         barcodes_in.append(all_lines)
+ 
     if options.n_cell is not None:
         barcodes_in = sample_barcodes(barcodes_in, options.n_cell, 
             options.minor_sample, options.random_seed)
     barcodes_out = pool_barcodes(barcodes_in, out_dir, options.doublet_rate, 
         seed=options.random_seed)
-    
-    ## VCF file
-    vcf_dat = load_VCF(options.region_file, biallelic_only=False, 
-                       load_sample=False)
-    chroms = vcf_dat['FixedINFO']['CHROM']
-    positions = [int(x) for x in vcf_dat['FixedINFO']['POS']]
-    
-    # fetch each position
-    if (options.nproc == 1):
-        BAM_FILE = out_dir + "/pooled.bam"
-        fetch_reads(samFile_list, chroms, positions, 
-            BAM_FILE, barcodes_in, barcodes_out)
-    else:
-        result = []
-        pool = multiprocessing.Pool(processes=options.nproc)
-        for ii in range(len(samFile_list)):
-            BAM_FILE = out_dir + "/pooled_temp%d.bam" %(ii)
-            print(ii, BAM_FILE)
-            result.append(pool.apply_async(fetch_reads, ([samFile_list[ii]], 
-                chroms, positions, BAM_FILE, [barcodes_in[ii]], 
-                [barcodes_out[ii]], "CB"), callback=show_progress))
-        pool.close()
-        pool.join()
+ 
+    if options.merge:
+        if (options.nproc == 1):
+            BAM_FILE = out_dir + "/pooled.bam"
+            merge_bams(samFile_list,BAM_FILE, barcodes_in, barcodes_out)
+        else:
+            result = []
+            pool = multiprocessing.Pool(processes=options.nproc)
+            for ii in range(len(samFile_list)):
+                BAM_FILE = out_dir + "/pooled_temp%d.bam" %(ii)
+                print(ii, BAM_FILE)
+                result.append(pool.apply_async(merge_bams, ([samFile_list[ii]], BAM_FILE, [barcodes_in[ii]], 
+                                                             [barcodes_out[ii]], "CB"), callback=show_progress))
+            pool.close()
+            pool.join()
 
-        ## merge bam files
-        file_list = [out_dir + "/pooled.bam"]
-        file_list += [out_dir + "/pooled_temp%d.bam" %(x) 
-                        for x in range(len(samFile_list))]
-        bashCommand = "samtools merge %s" %(" ".join(file_list))
-        pro = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
-        pro.communicate()[0]
-        for dd in range(len(samFile_list)):
-            os.remove(out_dir + "/pooled_temp%d.bam" %(dd))
-    print("")
+            ## merge bam files
+            file_list = [out_dir + "/pooled.bam"]
+            file_list += [out_dir + "/pooled_temp%d.bam" %(x) 
+                          for x in range(len(samFile_list))]
+            bashCommand = "samtools merge %s" %(" ".join(file_list))
+            print('command  ',bashCommand)
+            pro = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
+            pro.communicate()[0]
+            for dd in range(len(samFile_list)):
+                os.remove(out_dir + "/pooled_temp%d.bam" %(dd))
+            print("")
 
+
+    if not options.merge:
+        ## VCF file
+        vcf_dat = load_VCF(options.region_file, biallelic_only=False, 
+                           load_sample=False)
+        chroms = vcf_dat['FixedINFO']['CHROM']
+        positions = [int(x) for x in vcf_dat['FixedINFO']['POS']]
+        del vcf_dat
+        print('number of positions/chromosomes in the vcf: ',len(positions),'/',len(chroms))
+
+        # fetch each position
+        if (options.nproc == 1):
+            BAM_FILE = out_dir + "/pooled.bam"
+            fetch_reads(samFile_list, chroms, positions, 
+                        BAM_FILE, barcodes_in, barcodes_out)
+
+        elif (options.nproc > 1):
+            result = []
+            pool = multiprocessing.Pool(processes=options.nproc*len(samFile_list))
+            npositions=len(positions)
+            if options.shuffle:
+                mlist = list(zip(chroms, positions))
+                random.shuffle(mlist)
+                chroms, positions = zip(*mlist)
+                
+            npos=int(npositions/options.nproc)
+            posrange=[]
+            for n in range(options.nproc):
+                if n==options.nproc-1:
+                    posrange.append([n*npos,npositions])
+                else:
+                    posrange.append([n*npos,(n+1)*npos])
+            print('list of positions range: ',posrange)
+
+            for n in range(options.nproc):
+                for ii in range(len(samFile_list)):
+                    BAM_FILE = out_dir + "/pooled_temp_File{}_Pos{}.bam".format(ii,n)
+                    result.append(pool.apply_async(fetch_reads, ([samFile_list[ii]], 
+                                                                 chroms[posrange[n][0]:posrange[n][1]], positions[posrange[n][0]:posrange[n][1]], BAM_FILE, [barcodes_in[ii]], 
+                                                                 [barcodes_out[ii]], "CB"), callback=show_progress))
+
+            pool.close()
+            pool.join()
+
+        
+            ## remove duplicates
+            print("removing duplicates  : {}".format(str(datetime.timedelta(seconds=time.time()-start))))
+            for ii in range(len(samFile_list)):
+                outbam = pysam.AlignmentFile(out_dir + "/pooled_temp_File{}.bam".format(ii), "wb", template=check_pysam_chrom(out_dir + "/pooled_temp_File0_Pos0.bam", chroms[0])[0])
+                index={}
+                count=0
+                goodread=0
+                for n in range(len(posrange)):
+                    BAM_FILE = out_dir + "/pooled_temp_File{}_Pos{}.bam".format(ii,n)
+                    samfile = pysam.AlignmentFile(BAM_FILE, 'rb')
+                    for read in samfile:
+                        readID = read.query_name
+                        count+=1
+                        if index.get(readID,-1)<0:
+                            index[readID]=goodread
+                            outbam.write(read)
+                            goodread+=1
+                    samfile.close()
+                    os.remove(out_dir + "/pooled_temp_File{}_Pos{}.bam".format(ii, n))
+                outbam.close()
+                
+                print('for file {} total reads {} store reads {}'.format(out_dir + "/pooled_temp_File{}.bam".format(ii), count, len(index)))
+            ## merge bam files
+            print("Samtools merge : {}".format(str(datetime.timedelta(seconds=time.time()-start))))
+            file_list = [out_dir + "/pooled.bam"]
+            file_list += [out_dir + "/pooled_temp_File{}.bam".format(x) 
+                            for x in range(len(samFile_list))]
+            bashCommand = "samtools merge %s" %(" ".join(file_list))
+            print('command merge  ',bashCommand)
+            pro = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
+            pro.communicate()[0]
+            for dd in range(len(samFile_list)):
+                os.remove(out_dir + "/pooled_temp_File{}.bam".format(dd))
+
+    
+
+    print("Samtools sort : {}".format(str(datetime.timedelta(seconds=time.time()-start))))
     ## sort and index bam file
     bashCommand = "samtools sort %s -o %s" %(out_dir + "/pooled.bam", 
         out_dir + "/pooled.sorted.bam")
+    print('command  sort ',bashCommand)
     pro = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
     pro.communicate()[0]
     
+    print("Samtools index : {}".format(str(datetime.timedelta(seconds=time.time()-start))))
     bashCommand = "samtools index %s" %(out_dir + "/pooled.sorted.bam")
+    print('command  index ',bashCommand)
     pro = subprocess.Popen(bashCommand.split(), stdout=subprocess.PIPE)
     pro.communicate()[0]
 
     os.remove(out_dir + "/pooled.bam")
-    
+
+    print("The end : {}".format(str(datetime.timedelta(seconds=time.time()-start))))
     
 if __name__ == "__main__":
     main()

--- a/simulate/synth_pool.py
+++ b/simulate/synth_pool.py
@@ -96,7 +96,7 @@ def pool_barcodes(barcodes, out_dir, doublet_rate=None, sample_suffix=True,
 
 
 def fetch_reads(samFile_list, chroms, positions, outbam, 
-                barcodes_in, barcodes_out=None, cell_tag='CB', test=-1):
+                barcodes_in, barcodes_out=None, cell_tag='CB', test_val=-1):
     print('running fetch reads with vcf')
     """
     """
@@ -115,10 +115,10 @@ def fetch_reads(samFile_list, chroms, positions, outbam,
         reads_all_test =[]
         npostot=len(positions)
         for i in range(npostot):
-            if test>0 and ii>test:break
+            if test_val>0 and ii>test:break
             if int(i+1) % 10000 == 0:
                 if test<0: print("BAM: {} positions read: {:.2f}M   percent: {:.2f}%   reads stored: {}" .format(jobname.split('/')[-1], (i+1)/1000000, float(100*(i+1))/float(npostot), len(reads_all)))
-                else: print("BAM: {} positions read: {:.2f}M   percent: {:.2f}%   reads stored: {}" .format(jobname.split('/')[-1], (i+1)/1000000, float(100*(i+1))/float(test), len(reads_all)))
+                else: print("BAM: {} positions read: {:.2f}M   percent: {:.2f}%   reads stored: {}" .format(jobname.split('/')[-1], (i+1)/1000000, float(100*(i+1))/float(test_val), len(reads_all)))
             chrom = chroms[i]
             POS = positions[i]
             read=0
@@ -215,7 +215,7 @@ def main():
         help="Merge instead of fetch [default: %default]")
     parser.add_option("--shuffle", action="store_true", default=False,
         help="Shuffle the positions, only works on MT [default: %default]")
-    parser.add_option("--test", dest="testval", default=-1,
+    parser.add_option("--test", dest="test_val", default=-1,
         help="Set it to a value >0 to run only <test> read [default: %default]")
     
     group = OptionGroup(parser, "Cell barcodes sampling")
@@ -341,7 +341,7 @@ def main():
                     BAM_FILE = out_dir + "/pooled_temp_File{}_Pos{}.bam".format(ii,n)
                     result.append(pool.apply_async(fetch_reads, ([samFile_list[ii]], 
                                                                  chroms[posrange[n][0]:posrange[n][1]], positions[posrange[n][0]:posrange[n][1]], BAM_FILE, [barcodes_in[ii]], 
-                                                                 [barcodes_out[ii]], "CB", test=options.test), callback=show_progress))
+                                                                 [barcodes_out[ii]], "CB", test_val=options.test_val), callback=show_progress))
 
             pool.close()
             pool.join()

--- a/simulate/synth_pool.py
+++ b/simulate/synth_pool.py
@@ -105,14 +105,8 @@ def fetch_reads(samFile_list, chroms, positions, outbam,
     outbam = pysam.AlignmentFile(outbam, "wb", template=samFile_list[0])
     if barcodes_out is None:
         barcodes_out = barcodes_in.copy()
-    
-
-    print ('N positions     : ',len(positions))
-    print ('First positions : ',positions[0])
-    print ('Last positions  : ',positions[-1])
  
     for ss in range(len(samFile_list)):
-        print('file {} out of {} type {}'.format(ss+1,len(samFile_list), samFile_list[ss]))
         samFile = samFile_list[ss]
         _barcodes_in = barcodes_in[ss]
         _barcodes_out = barcodes_out[ss]

--- a/simulate/synth_pool.py
+++ b/simulate/synth_pool.py
@@ -117,7 +117,8 @@ def fetch_reads(samFile_list, chroms, positions, outbam,
         for i in range(npostot):
             if test>0 and ii>test:break
             if int(i+1) % 10000 == 0:
-                print("BAM: {} positions read: {:.2f}M   percent: {:.2f}%   reads stored: {}" .format(jobname.split('/')[-1], (i+1)/1000000, float(100*(i+1))/float(npostot), len(reads_all)))
+                if test<0: print("BAM: {} positions read: {:.2f}M   percent: {:.2f}%   reads stored: {}" .format(jobname.split('/')[-1], (i+1)/1000000, float(100*(i+1))/float(npostot), len(reads_all)))
+                else: print("BAM: {} positions read: {:.2f}M   percent: {:.2f}%   reads stored: {}" .format(jobname.split('/')[-1], (i+1)/1000000, float(100*(i+1))/float(test), len(reads_all)))
             chrom = chroms[i]
             POS = positions[i]
             read=0
@@ -315,7 +316,7 @@ def main():
         if (options.nproc == 1):
             BAM_FILE = out_dir + "/pooled.bam"
             fetch_reads(samFile_list, chroms, positions, 
-                        BAM_FILE, barcodes_in, barcodes_out)
+                        BAM_FILE, barcodes_in, barcodes_out, test=options.test)
 
         elif (options.nproc > 1):
             result = []
@@ -340,7 +341,7 @@ def main():
                     BAM_FILE = out_dir + "/pooled_temp_File{}_Pos{}.bam".format(ii,n)
                     result.append(pool.apply_async(fetch_reads, ([samFile_list[ii]], 
                                                                  chroms[posrange[n][0]:posrange[n][1]], positions[posrange[n][0]:posrange[n][1]], BAM_FILE, [barcodes_in[ii]], 
-                                                                 [barcodes_out[ii]], "CB"), callback=show_progress))
+                                                                 [barcodes_out[ii]], "CB", test=options.test), callback=show_progress))
 
             pool.close()
             pool.join()


### PR DESCRIPTION
This Pull Request contains:

- reduction of memory consumption
- multi threading based on splitting the positions and number of input files
- option `--merge` when no input vcf is use to still use the synth polling 
- option `--shuffle` to shuffle the input positions (makes each thread length more uniform)
- option `--test` to run only a subset of positions 