### PR TITLE
Add all used FORMAT tags when writing VCF files.

### DIFF
--- a/vireoSNP/utils/vireo_doublet.py
+++ b/vireoSNP/utils/vireo_doublet.py
@@ -77,9 +77,9 @@ def predict_doublet(vobj, AD, DP, update_GT=True, update_ID=True,
             print("For update_GT, please turn on update_ID.")
     
     prob_doublet = ID_prob_both[:, vobj.n_donor:]
-    prob_signlet = ID_prob_both[:, :vobj.n_donor]
+    prob_singlet = ID_prob_both[:, :vobj.n_donor]
     
-    return prob_doublet, prob_signlet, logLik_ratio
+    return prob_doublet, prob_singlet, logLik_ratio
 
 
 def add_doublet_theta(beta_mu, beta_sum):


### PR DESCRIPTION
Add a proper VCF header to "cellSNP.base.vcf.gz" so other tools can work with it.

Before this patch Picard couldn't work with the "GT_donors.vireo.vcf.gz" file at all as it requires complete VCF header by default and BCFtools would emit warnings about FORMAT fields not defined in the header and assuming "Type=String" instead of the correct type.