### PR TITLE
Check if cell data has any variant and check if cell data variants ha…

### DIFF
--- a/vireoSNP/vireo.py
+++ b/vireoSNP/vireo.py
@@ -141,26 +141,34 @@ def main():
         cell_dat['DP'] = cell_dat['DP'][:,cellRange[0]:cellRange[1]]
         cell_dat['samples'] = cell_dat['samples'][cellRange[0]:cellRange[1]]
 
+    if cell_dat['AD'].shape[0] == 0:
+        print("Error: cell data in vcf file, or cellSNP output folder, or "
+            "vartrix's alt.mtx,ref.mtx,barcodes.tsv does not contain any variants.")
+        sys.exit(1)
 
     ## input donor genotype
     n_donor = options.n_donor
     if options.donor_file is not None:
         if "variants" not in cell_dat.keys():
-            print("No variants information is loaded, please provide base.vcf.gz")
+            print("Error: No variants information is loaded, please provide base.vcf.gz")
             sys.exit(1)
 
         print("[vireo] Loading donor VCF file ...")
         donor_vcf = load_VCF(options.donor_file, biallelic_only=True,
                              sparse=False, format_list=[options.geno_tag])
-        
+
         if (donor_vcf['n_SNP_tagged'][0] < 
             (0.1 * len(donor_vcf['GenoINFO'][options.geno_tag]))):
-            print("[vireo] No " + options.geno_tag + " tag in donor genotype; "
+            print("Error: No " + options.geno_tag + " tag in donor genotype; "
                 "please try another tag for genotype, e.g., GT")
             print("        %s" %options.donor_file)
             sys.exit(1)
 
         cell_dat, donor_vcf = match_donor_VCF(cell_dat, donor_vcf)
+        if len(donor_vcf['GenoINFO'][options.geno_tag]) == 0:
+            print("Error: No matching variants found between cell data and donor VCF.")
+            sys.exit(1)
+
         donor_GPb = parse_donor_GPb(donor_vcf['GenoINFO'][options.geno_tag],
             options.geno_tag)
 


### PR DESCRIPTION
…ve any overlap with donor VCF file.

Check if cell data has any variant and check if cell data variants have any overlap with donor VCF file.

Examples:

  - Running vireo with a cellSNP directory that does not have any variant (as provided CBs for cellSNP-lite did not overlap with any variants).

    [vireo] Loading cell folder ... Error: cell data in vcf file, or cellSNP output folder, or vartrix's alt.mtx,ref.mtx,barcodes.tsv does not contain any variants.

  - Running vireo with a VCF file that does not overlap at all with the SNPs used in cellSNP-lite.

    cellSNP-lite [vireo] Loading cell folder ... [vireo] Loading donor VCF file ... /conda/envs/cellsnp/lib/python3.11/site-packages/numpy/core/fromnumeric.py:3504: RuntimeWarning: Mean of empty slice. return _methods._mean(a, axis=axis, dtype=dtype, /conda/envs/cellsnp/lib/python3.11/site-packages/numpy/core/_methods.py:129: RuntimeWarning: invalid value encountered in scalar divide ret = ret.dtype.type(ret / rcount) [vireo] warning: no variants matched to donor VCF, please check chr format! Error: No matching variants found between cell data and donor VCF.

Before:

    [vireo] Loading cell folder ... [vireo] Loading donor VCF file ... /conda/envs/cellsnp/lib/python3.11/site-packages/numpy/core/fromnumeric.py:3504: RuntimeWarning: Mean of empty slice. return _methods._mean(a, axis=axis, dtype=dtype, /conda/envs/cellsnp/lib/python3.11/site-packages/numpy/core/_methods.py:129: RuntimeWarning: invalid value encountered in scalar divide ret = ret.dtype.type(ret / rcount) [vireo] warning: no variants matched to donor VCF, please check chr format! Traceback (most recent call last): File "/conda/envs/cellsnp/bin/vireo", line 8, in <module> sys.exit(main()) ^^^^^^ File "/conda/envs/cellsnp/lib/python3.11/site-packages/vireoSNP/vireo.py", line 168, in main donor_GPb = parse_donor_GPb(donor_vcf['GenoINFO'][options.geno_tag], ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/conda/envs/cellsnp/lib/python3.11/site-packages/vireoSNP/utils/vcf_utils.py", line 328, in parse_donor_GPb GT_prob = np.zeros((len(GT_dat), len(GT_dat[0]), 3)) ~~~~~~^^^ IndexError: list index out of range

    The traceback obscures the warning message.